### PR TITLE
dis-sdk适配EPS企业项目，在指定接口header中放入X-EPSPROJECT-ID，用于判断该用户在企业项目中的权限

### DIFF
--- a/huaweicloud-sdk-java-dis/pom.xml
+++ b/huaweicloud-sdk-java-dis/pom.xml
@@ -28,6 +28,36 @@
             <version>1.3.13-SNAPSHOT</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.huawei.hwclouds.bigdata</groupId>
+            <artifactId>cloud-api-client</artifactId>
+            <version>1.0.8</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-core-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>htrace-core</artifactId>
+                    <groupId>org.apache.htrace</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>hadoop-mapreduce-client-app</artifactId>
+                    <groupId>org.apache.hadoop</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jetty-util</artifactId>
+                    <groupId>org.mortbay.jetty</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+            <version>1.2.75</version>
+        </dependency>
+
         <!-- sdk签名方法 -->
         <!-- <dependency>
             <groupId>com.huawei.apigateway</groupId>

--- a/huaweicloud-sdk-java-dis/src/main/java/com/huaweicloud/dis/Constants.java
+++ b/huaweicloud-sdk-java-dis/src/main/java/com/huaweicloud/dis/Constants.java
@@ -195,4 +195,11 @@ public interface Constants
 
     String COMPRESS_ZSTD_CONTENT_LENGTH = "x-dis-zstd-content-length";
 
+    final String STREAMINFO_EXPIRETIME = "expireTime";
+
+    final String STREAMINFO_REAL_EXPIRETIME = "realExpireTime";
+
+    final String CACHE_EXPIRETIME = "cacheTime";
+
+    final long CACHE_TIME_OUT = 5;
 }

--- a/huaweicloud-sdk-java-dis/src/main/java/com/huaweicloud/dis/DISClient.java
+++ b/huaweicloud-sdk-java-dis/src/main/java/com/huaweicloud/dis/DISClient.java
@@ -243,8 +243,11 @@ public class DISClient extends AbstractDISClient implements DIS {
     protected final PutRecordsResult innerPutRecords(PutRecordsRequest putRecordsParam) {
         // Decorate PutRecordsRequest if needed
         putRecordsParam = decorateRecords(putRecordsParam);
-
+        String epsId = Utils.getStreamEpsId(putRecordsParam.getStreamName(), disConfig);
         Request<HttpRequest> request = new DefaultRequest<>(Constants.SERVICENAME);
+        if (epsId != null) {
+            request.addHeader("X-EPSPROJECT-ID", epsId);
+        }
         request.setHttpMethod(HttpMethodName.POST);
 
         final String resourcePath =
@@ -280,7 +283,11 @@ public class DISClient extends AbstractDISClient implements DIS {
      * Internal API
      */
     protected final GetPartitionCursorResult innerGetPartitionCursor(GetPartitionCursorRequest getPartitionCursorParam) {
+        String epsId = Utils.getStreamEpsId(getPartitionCursorParam.getStreamName(), disConfig);
         Request<HttpRequest> request = new DefaultRequest<>(Constants.SERVICENAME);
+        if (epsId != null) {
+            request.addHeader("X-EPSPROJECT-ID", epsId);
+        }
         request.setHttpMethod(HttpMethodName.GET);
 
         final String resourcePath =
@@ -386,7 +393,11 @@ public class DISClient extends AbstractDISClient implements DIS {
 
     protected final UpdatePartitionCountResult innerUpdatePartitionCount(
             UpdatePartitionCountRequest updatePartitionCountRequest) {
+        String epsId = Utils.getStreamEpsId(updatePartitionCountRequest.getStreamName(), disConfig);
         Request<HttpRequest> request = new DefaultRequest<>(Constants.SERVICENAME);
+        if (epsId != null) {
+            request.addHeader("X-EPSPROJECT-ID", epsId);
+        }
         request.setHttpMethod(HttpMethodName.PUT);
 
         final String resourcePath = ResourcePathBuilder.standard()
@@ -404,7 +415,11 @@ public class DISClient extends AbstractDISClient implements DIS {
     }
 
     protected final DeleteStreamResult innerDeleteStream(DeleteStreamRequest deleteStreamRequest) {
+        String epsId = Utils.getStreamEpsId(deleteStreamRequest.getStreamName(), disConfig);
         Request<HttpRequest> request = new DefaultRequest<>(Constants.SERVICENAME);
+        if (epsId != null) {
+            request.addHeader("X-EPSPROJECT-ID", epsId);
+        }
         request.setHttpMethod(HttpMethodName.DELETE);
 
         final String resourcePath =
@@ -546,7 +561,11 @@ public class DISClient extends AbstractDISClient implements DIS {
     }
 
     protected final CommitCheckpointResult innerCommitCheckpoint(CommitCheckpointRequest commitCheckpointParam) {
+        String epsId = Utils.getStreamEpsId(commitCheckpointParam.getStreamName(), disConfig);
         Request<HttpRequest> request = new DefaultRequest<>(Constants.SERVICENAME);
+        if (epsId != null) {
+            request.addHeader("X-EPSPROJECT-ID", epsId);
+        }
         request.setHttpMethod(HttpMethodName.POST);
 
         final String resourcePath = ResourcePathBuilder.standard()
@@ -563,7 +582,11 @@ public class DISClient extends AbstractDISClient implements DIS {
     }
 
     protected final GetCheckpointResult innerGetCheckpoint(GetCheckpointRequest getCheckpointRequest) {
+        String epsId = Utils.getStreamEpsId(getCheckpointRequest.getStreamName(), disConfig);
         Request<HttpRequest> request = new DefaultRequest<>(Constants.SERVICENAME);
+        if (epsId != null) {
+            request.addHeader("X-EPSPROJECT-ID", epsId);
+        }
         request.setHttpMethod(HttpMethodName.GET);
 
         final String resourcePath = ResourcePathBuilder.standard()
@@ -581,7 +604,11 @@ public class DISClient extends AbstractDISClient implements DIS {
     }
 
     protected final DeleteCheckpointResult innerDeleteCheckpoint(DeleteCheckpointRequest deleteCheckpointRequest) {
+        String epsId = Utils.getStreamEpsId(deleteCheckpointRequest.getStreamName(), disConfig);
         Request<HttpRequest> request = new DefaultRequest<>(Constants.SERVICENAME);
+        if (epsId != null) {
+            request.addHeader("X-EPSPROJECT-ID", epsId);
+        }
         request.setHttpMethod(HttpMethodName.DELETE);
 
         final String resourcePath = ResourcePathBuilder.standard()
@@ -618,7 +645,11 @@ public class DISClient extends AbstractDISClient implements DIS {
     }
 
     protected UpdateStreamResult innerUpdateStream(UpdateStreamRequest updateStreamRequest) {
+        String epsId = Utils.getStreamEpsId(updateStreamRequest.getStreamName(), disConfig);
         Request<HttpRequest> request = new DefaultRequest<>(Constants.SERVICENAME);
+        if (epsId != null) {
+            request.addHeader("X-EPSPROJECT-ID", epsId);
+        }
         request.setHttpMethod(HttpMethodName.PUT);
 
         final String resourcePath = ResourcePathBuilder.standard()
@@ -647,7 +678,11 @@ public class DISClient extends AbstractDISClient implements DIS {
     }
 
     public final CreateTransferTaskResult innerCreateTransferTask(CreateTransferTaskRequest createTransferTaskRequest) {
+        String epsId = Utils.getStreamEpsId(createTransferTaskRequest.getStreamName(), disConfig);
         Request<HttpRequest> request = new DefaultRequest<>(Constants.SERVICENAME);
+        if (epsId != null) {
+            request.addHeader("X-EPSPROJECT-ID", epsId);
+        }
         request.setHttpMethod(HttpMethodName.POST);
 
         final String resourcePath = ResourcePathBuilder.standard()
@@ -668,7 +703,11 @@ public class DISClient extends AbstractDISClient implements DIS {
     }
 
     public final UpdateTransferTaskResult innerUpdateTransferTask(UpdateTransferTaskRequest updateTransferTaskRequest) {
+        String epsId = Utils.getStreamEpsId(updateTransferTaskRequest.getStreamName(), disConfig);
         Request<HttpRequest> request = new DefaultRequest<>(Constants.SERVICENAME);
+        if (epsId != null) {
+            request.addHeader("X-EPSPROJECT-ID", epsId);
+        }
         request.setHttpMethod(HttpMethodName.PUT);
 
         final String resourcePath = ResourcePathBuilder.standard()
@@ -689,7 +728,11 @@ public class DISClient extends AbstractDISClient implements DIS {
     }
 
     public final DeleteTransferTaskResult innerDeleteTransferTask(DeleteTransferTaskRequest deleteTransferTaskRequest) {
+        String epsId = Utils.getStreamEpsId(deleteTransferTaskRequest.getStreamName(), disConfig);
         Request<HttpRequest> request = new DefaultRequest<>(Constants.SERVICENAME);
+        if (epsId != null) {
+            request.addHeader("X-EPSPROJECT-ID", epsId);
+        }
         request.setHttpMethod(HttpMethodName.DELETE);
 
         final String resourcePath = ResourcePathBuilder.standard()
@@ -712,7 +755,11 @@ public class DISClient extends AbstractDISClient implements DIS {
 
     public final DescribeTransferTaskResult innerDescribeTransferTask(
             DescribeTransferTaskRequest describeTransferTaskRequest) {
+        String epsId = Utils.getStreamEpsId(describeTransferTaskRequest.getStreamName(), disConfig);
         Request<HttpRequest> request = new DefaultRequest<>(Constants.SERVICENAME);
+        if (epsId != null) {
+            request.addHeader("X-EPSPROJECT-ID", epsId);
+        }
         request.setHttpMethod(HttpMethodName.GET);
 
         final String resourcePath = ResourcePathBuilder.standard()
@@ -735,7 +782,11 @@ public class DISClient extends AbstractDISClient implements DIS {
     }
 
     public final ListTransferTasksResult innerListTransferTasks(ListTransferTasksRquest listTransferTasksRquest) {
+        String epsId = Utils.getStreamEpsId(listTransferTasksRquest.getStreamName(), disConfig);
         Request<HttpRequest> request = new DefaultRequest<>(Constants.SERVICENAME);
+        if (epsId != null) {
+            request.addHeader("X-EPSPROJECT-ID", epsId);
+        }
         request.setHttpMethod(HttpMethodName.GET);
 
         final String resourcePath = ResourcePathBuilder.standard()

--- a/huaweicloud-sdk-java-dis/src/main/java/com/huaweicloud/dis/util/cache/StreamInfoCache.java
+++ b/huaweicloud-sdk-java-dis/src/main/java/com/huaweicloud/dis/util/cache/StreamInfoCache.java
@@ -1,0 +1,68 @@
+package com.huaweicloud.dis.util.cache;
+
+import static com.huaweicloud.dis.Constants.CACHE_EXPIRETIME;
+import static com.huaweicloud.dis.Constants.STREAMINFO_EXPIRETIME;
+import static com.huaweicloud.dis.Constants.STREAMINFO_REAL_EXPIRETIME;
+
+import com.huawei.bigdata.dataaccess.common.cache.Cache;
+
+import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap;
+import com.googlecode.concurrentlinkedhashmap.Weighers;
+
+import java.util.Map;
+
+public class StreamInfoCache<K, V> implements Cache {
+
+    public static final int DEFAULT_CONCURENCY_LEVEL = 32;
+
+    private final ConcurrentLinkedHashMap map;
+
+    public StreamInfoCache(int capacity) {
+        this(capacity, DEFAULT_CONCURENCY_LEVEL);
+    }
+
+    public StreamInfoCache(int capacity, int concurrency) {
+        map = new ConcurrentLinkedHashMap.Builder<K, V>().weigher(Weighers.singleton())
+            .initialCapacity(capacity)
+            .maximumWeightedCapacity(capacity)
+            .concurrencyLevel(concurrency)
+            .build();
+    }
+
+    public boolean isMemoryExpired(Map<String, String> streamInfo) {
+        long cacheTime = Long.parseLong(streamInfo.get(STREAMINFO_EXPIRETIME));
+        long expiresRealTime;
+        if (streamInfo.get(STREAMINFO_REAL_EXPIRETIME) != null) {
+            expiresRealTime = Long.parseLong(streamInfo.get(STREAMINFO_REAL_EXPIRETIME));
+        } else {
+            expiresRealTime = cacheTime;
+        }
+        return System.currentTimeMillis() > expiresRealTime || System.currentTimeMillis() > cacheTime;
+
+    }
+
+    @Override
+    public void put(Object key, Object value) {
+        map.put(key, value);
+    }
+
+    @Override
+    public Object get(Object key) {
+        Map<String, String> userInfo = (Map<String, String>) map.get(key);
+        if (null != userInfo && !userInfo.isEmpty()) {
+            return userInfo;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void remove(Object key) {
+        map.remove(key);
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return map.containsKey(key);
+    }
+}

--- a/huaweicloud-sdk-java-dis/src/main/java/com/huaweicloud/dis/util/cache/StreamInfoCacheManager.java
+++ b/huaweicloud-sdk-java-dis/src/main/java/com/huaweicloud/dis/util/cache/StreamInfoCacheManager.java
@@ -1,0 +1,12 @@
+package com.huaweicloud.dis.util.cache;
+
+public class StreamInfoCacheManager {
+    private static final int CACHE_SIZE = 10000;
+
+    private static StreamInfoCache streamInfoInstance = new StreamInfoCache(CACHE_SIZE);
+
+    public static StreamInfoCache getAkUserInfoCacheInstance() {
+        return streamInfoInstance;
+    }
+
+}


### PR DESCRIPTION
dis-sdk适配EPS企业项目，在指定接口header中放入X-EPSPROJECT-ID，用于判断该用户在企业项目中的权限需要放企业项目ID的有：删除通道、更新通道、上传数据、获取数据游标、查看checkpoint详情、删除checkpoint、新增转储任务、修改转储任务、删除转储任务、查看转储任务、查看转储任务列表