### PR TITLE
upgrade version for log4j, zstd, lz4, snappy for CVE-2021-44228, CVE-2021-45046, CVE-2021-45105, CVE-2021-44832, CVE-2020-9488, CVE-2021-24032, CVE-2021-3520

### DIFF
--- a/huaweicloud-sdk-java-dis/pom.xml
+++ b/huaweicloud-sdk-java-dis/pom.xml
@@ -19,7 +19,7 @@
         <slf4j.version>1.7.26</slf4j.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpasyncclient.version>4.1.4</httpasyncclient.version>
-        <log4j.version>2.13.3</log4j.version>
+        <log4j.version>2.17.2</log4j.version>
     </properties>
     <dependencies>
         <dependency>
@@ -63,13 +63,13 @@
         <dependency>
             <groupId>org.lz4</groupId>
             <artifactId>lz4-java</artifactId>
-            <version>1.7.1</version>
+            <version>1.8.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
-            <version>1.4.3-1</version>
+            <version>1.5.2-2</version>
         </dependency>
 
         <!-- sdk-core的sign方法依赖 -->
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.7.2</version>
+            <version>1.1.8.4</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>

--- a/huaweicloud-sdk-java-dis/src/main/java/com/huaweicloud/dis/util/compress/Lz4Util.java
+++ b/huaweicloud-sdk-java-dis/src/main/java/com/huaweicloud/dis/util/compress/Lz4Util.java
@@ -34,6 +34,15 @@ public class Lz4Util {
      * @return
      */
     public static byte[] decompressByte(byte[] compressorByte, int srcLength) {
+        if (srcLength < 0) {
+          throw new IndexOutOfBoundsException(
+              "CVE-2021-3520: There's a flaw in lz4. An attacker who submits a crafted file to "
+                  + "an application linked with lz4 may be able to trigger an integer overflow, " 
+                  + "leading to calling of memmove() on a negative size argument, causing an " 
+                  + "out-of-bounds write and/or a crash. The greatest impact of this flaw is to " 
+                  + "availability, with some potential impact to confidentiality and integrity " 
+                  + "as well.");
+        }
         LZ4Factory factory = LZ4Factory.fastestInstance();
         LZ4FastDecompressor decompressor = factory.fastDecompressor();
         return decompressor.decompress(compressorByte, srcLength);


### PR DESCRIPTION
upgrade version for log4j, zstd, lz4, snappy for CVE-2021-44228, CVE-2021-45046, CVE-2021-45105, CVE-2021-44832, CVE-2020-9488, CVE-2021-24032, CVE-2021-3520